### PR TITLE
Use fetch to submit form with success redirect and error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1017,7 +1017,21 @@ Créneau de livraison: ${dateLivraisonInput.value} entre ${heureDebutLivraisonIn
 
       confirmOrderBtn.addEventListener('click', () => {
         if(rememberMeCheckbox.checked) saveUserInfo();
-        form.submit();
+        fetch(form.action, {
+          method: 'POST',
+          body: new FormData(form)
+        })
+        .then(response => {
+          if (response.ok) {
+            const nextUrl = form.querySelector('input[name="_next"]').value;
+            window.location.href = nextUrl;
+          } else {
+            throw new Error('Network response was not ok');
+          }
+        })
+        .catch(() => {
+          alert("Impossible d’envoyer la commande");
+        });
       });
 
       // --- INITIALIZATION ---


### PR DESCRIPTION
## Summary
- Replace form.submit() with fetch to send form data to FormSubmit
- Redirect to `_next` URL on success
- Alert user if the order fails to send

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a36d8cc8320a8bef87e24f98183