### PR TITLE
Add SRI hashes for external CSS and document update process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Formulaire de commande
+
+## Updating external CSS SRI hashes
+
+When upgrading CDN-hosted CSS libraries such as Leaflet or Font Awesome, update the `integrity` attributes in `index.html`:
+
+1. Download the file and compute its Subresource Integrity hash:
+   ```bash
+   curl -s <URL> | openssl dgst -sha384 -binary | base64 -w0
+   ```
+   Replace `-sha384` with `-sha256` if the existing tag uses SHA-256.
+2. Prefix the output with the algorithm (`sha384-` or `sha256-`) and place the value in the `integrity` attribute.
+3. Ensure `crossorigin="anonymous"` is present on the `<link>` tag.
+
+Run `npm test` to verify the project still builds after any update.

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Commande - Les Coursiers Montpelliérains</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous"/>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="styles/main.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous">
+  <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- secure Font Awesome and Leaflet CDN stylesheets with SRI and `crossorigin="anonymous"`
- add README instructions on generating new SRI hashes when upgrading libraries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab89bfaba883208e4328530efff193