### PR TITLE
fix: set anonymous crossorigin on Leaflet script

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     </div>
   </div>
 
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>
     <script src="scripts/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- set Leaflet script `crossorigin` attribute to `anonymous`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8bc448608320b3a8f117160a7fe0