### PR TITLE
Parse X-Forwarded-For for rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Formulaire de commande
 
+## Proxy requirements
+
+When deploying behind a reverse proxy, ensure it reliably sets the `X-Forwarded-For` header with the originating client's IP address. The server uses only the first IP in this header for rate limiting.
+
 ## Updating external CSS SRI hashes
 
 When upgrading CDN-hosted CSS libraries such as Leaflet or Font Awesome, update the `integrity` attributes in `index.html`:

--- a/server.js
+++ b/server.js
@@ -59,7 +59,8 @@ function saveOrder(data) {
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST' && req.url === '/api/orders') {
-    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const forwardedFor = req.headers['x-forwarded-for'];
+    const ip = forwardedFor ? forwardedFor.split(',')[0].trim() : req.socket.remoteAddress;
     if (isRateLimited(ip)) {
       res.writeHead(429, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Too many requests' }));


### PR DESCRIPTION
## Summary
- Only use the first entry of the `X-Forwarded-For` header when tracking request IPs
- Document that deployments behind a proxy must ensure this header is set reliably

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d76b0608320803cc6ef5486afa4