### PR TITLE
feat: enforce form content type

### DIFF
--- a/server.js
+++ b/server.js
@@ -66,6 +66,12 @@ const server = http.createServer((req, res) => {
       res.end(JSON.stringify({ error: 'Too many requests' }));
       return;
     }
+    const contentType = req.headers['content-type'];
+    if (contentType !== 'application/x-www-form-urlencoded') {
+      res.writeHead(415, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Unsupported Media Type' }));
+      return;
+    }
 
     let body = '';
     req.on('data', chunk => {


### PR DESCRIPTION
## Summary
- validate `Content-Type` for `/api/orders` requests
- reject unsupported media types with a 415 response

## Testing
- `npm test`
- `curl -i -X POST http://localhost:3000/api/orders -H "Content-Type: application/x-www-form-urlencoded" -d "name=foo&address=bar"`


------
https://chatgpt.com/codex/tasks/task_e_68ab8e5d10b083208506d565e8a50a84